### PR TITLE
When it the focus is in rocketbar, apps_name will be empty

### DIFF
--- a/mtbf_driver/MtbfTestCase.py
+++ b/mtbf_driver/MtbfTestCase.py
@@ -64,7 +64,9 @@ class GaiaMtbfTestCase(GaiaTestCase):
             self.device.unlock()
 
         # kill FTU if possible
-        if self.apps.displayed_app.name.upper() == "FTU":
+        if self.apps.displayed_app.name == None:
+            pass
+        elif self.apps.displayed_app.name.upper() == "FTU":
             self.apps.kill(self.apps.displayed_app)
 
         if full_reset:

--- a/mtbf_driver/MtbfTestCase.py
+++ b/mtbf_driver/MtbfTestCase.py
@@ -107,7 +107,8 @@ class GaiaMtbfTestCase(GaiaTestCase):
             # don't remove contact data
             # self.data_layer.remove_all_contacts()
 
-            # reset to home screen
+            # reset to home screen (dispacth event first to avoid None object in touch_home_button)
+            self.device._dispatch_home_button_event()
             self.device.touch_home_button()
 
         # disable sound completely


### PR DESCRIPTION
Default System app would be no apps name attribute. In that case, no upper()/lower() can be performed.
@zapion, r?