### PR TITLE
B2G info nothread

### DIFF
--- a/mtbf_driver/mtbf.py
+++ b/mtbf_driver/mtbf.py
@@ -269,7 +269,7 @@ class MTBF_Driver:
                 os.system(b2gps_cmd)
                 os.system(top_cmd)
 
-                b2ginfo_cmd = "adb shell b2g-info -t > " + os.path.join(out_dir, "b2ginfo" + str(current_round))
+                b2ginfo_cmd = "adb shell b2g-info > " + os.path.join(out_dir, "b2ginfo" + str(current_round))
                 b2gprocrank_cmd = "adb shell b2g-procrank --oom > " + os.path.join(out_dir, "b2gprocrank" + str(current_round))
                 os.system(b2ginfo_cmd)
                 os.system(b2gprocrank_cmd)

--- a/mtbf_driver/mtbf.py
+++ b/mtbf_driver/mtbf.py
@@ -163,6 +163,11 @@ class MTBF_Driver:
                 except NoSectionError as e:
                     self.logger.error(e)
                     continue
+                # I suggest we could catch DMerror duirng run_tests, because most of these DMError problems are not the
+                # testing target of MTBF
+                except DMError as de:
+                    self.logger.error(de)
+                    continue
             marionette = self.runner.marionette
             httpd = self.runner.httpd
             self.passed = self.runner.passed + self.passed

--- a/mtbf_driver/tests/test_dummy_case.py
+++ b/mtbf_driver/tests/test_dummy_case.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 class DummyTestCase(GaiaMtbfTestCase):
     # TODO: bug 1147731 will change the behavior of lock, unlock screen, very possible to damage this test
+    def cleanup_gaia(self, full_reset=True):
+        pass
+
     def setUp(self):
         GaiaMtbfTestCase.setUp(self)
         self.marionette.switch_to_frame()


### PR DESCRIPTION
To address B2G info threads issue. 
Also, bring back Shako's changes on cleanup gaia in dummy test.