### PR TITLE
override get_version_info of mozversion

### DIFF
--- a/mtbf_driver/mtbf.py
+++ b/mtbf_driver/mtbf.py
@@ -29,9 +29,9 @@ class MTBFTestRunner(GaiaTestRunner):
                                                              sources=self.sources,
                                                              dm_type=os.environ.get('DM_TRANS', 'adb'),
                                                              device_serial=self.device_serial)
+            mozversion.get_version = self._new_get_version_info
         else:
             self.saved_version_info = input_version_info
-        mozversion.get_version = self._new_get_version_info
         return self.saved_version_info
 
     def _new_get_version_info(self,binary=None, sources=None, dm_type=None, host=None,

--- a/mtbf_driver/mtbf.py
+++ b/mtbf_driver/mtbf.py
@@ -17,8 +17,6 @@ from utils.step_gen import RandomStepGen, ReplayStepGen
 from utils.time_utils import time2sec
 
 import mozversion
-import traceback
-from marionette.runner.mixins.b2g import get_dm
 
 
 class MTBFTestRunner(GaiaTestRunner):

--- a/mtbf_driver/mtbf.py
+++ b/mtbf_driver/mtbf.py
@@ -29,10 +29,9 @@ class MTBFTestRunner(GaiaTestRunner):
                                                              sources=self.sources,
                                                              dm_type=os.environ.get('DM_TRANS', 'adb'),
                                                              device_serial=self.device_serial)
-            mozversion.get_version = self._new_get_version_info
         else:
             self.saved_version_info = input_version_info
-            mozversion.get_version = self._new_get_version_info
+        mozversion.get_version = self._new_get_version_info
         return self.saved_version_info
 
     def _new_get_version_info(self,binary=None, sources=None, dm_type=None, host=None,

--- a/mtbf_driver/mtbf.py
+++ b/mtbf_driver/mtbf.py
@@ -36,7 +36,7 @@ class MTBFTestRunner(GaiaTestRunner):
 
     def _new_get_version_info(self,binary=None, sources=None, dm_type=None, host=None,
                 device_serial=None, adb_host=None, adb_port=None):
-        self.logger.info("get_version of mozversion is overrided!!!")
+        self.logger.info("Using existing version info instead!")
 
 
 class MTBF_Driver:

--- a/mtbf_driver/mtbf.py
+++ b/mtbf_driver/mtbf.py
@@ -16,10 +16,35 @@ from utils.memory_report_args import memory_report_args
 from utils.step_gen import RandomStepGen, ReplayStepGen
 from utils.time_utils import time2sec
 
+import mozversion
+import traceback
+from marionette.runner.mixins.b2g import get_dm
+
+
+class MTBFTestRunner(GaiaTestRunner):
+
+    saved_version_info = None
+
+    def get_version_info(self, input_version_info=None):
+        if input_version_info is None:
+            self.saved_version_info = mozversion.get_version(binary=self.bin,
+                                                             sources=self.sources,
+                                                             dm_type=os.environ.get('DM_TRANS', 'adb'),
+                                                             device_serial=self.device_serial)
+            mozversion.get_version = self._new_get_version_info
+        else:
+            self.saved_version_info = input_version_info
+            mozversion.get_version = self._new_get_version_info
+        return self.saved_version_info
+
+    def _new_get_version_info(self,binary=None, sources=None, dm_type=None, host=None,
+                device_serial=None, adb_host=None, adb_port=None):
+        self.logger.info("get_version of mozversion is overrided!!!")
+
 
 class MTBF_Driver:
 
-    runner_class = GaiaTestRunner
+    runner_class = MTBFTestRunner
     parser_class = GaiaTestOptions
     start_time = 0
     running_time = 0
@@ -132,6 +157,8 @@ class MTBF_Driver:
         httpd = None
         self.logger.info("Starting MTBF....")
 
+        version_info = None
+
         while(True):
             self.collect_metrics(current_round)
             current_round = current_round + 1
@@ -156,6 +183,10 @@ class MTBF_Driver:
             tests = sg.generate()
             file_name, file_path = zip(*tests)
             self.ttr = self.ttr + list(file_name)
+
+            if version_info is None:
+                version_info = self.runner.get_version_info(version_info)
+
             for i in range(0, 10):
                 try:
                     self.runner.run_tests(file_path)


### PR DESCRIPTION
create a new function to check if the version_info is created, then we override the mozversion.get_version, so the rest of rounds will not pull file from device for get_version purpose

@zapion , @ypwalter r?